### PR TITLE
Sync the variables' values to the ones generating the best cost value.

### DIFF
--- a/dccp/problem.py
+++ b/dccp/problem.py
@@ -91,6 +91,9 @@ def dccp(
             else:
                 for var in self.variables():
                     var.value = result_record[var]
+    # set the variables' values to the ones generating the best cost value.
+    for var in self.variables():
+        var.value = result_record[var]
     return result
 
 


### PR DESCRIPTION
```
result = myprob.solve(method='dccp')
print("x =", x.value)
```

The above example of `dccp` shows that we can do `x.value` to get the value that generates the result. This is true only if we set `ccp_times = 1`. When `ccp_times > 1`, `x.value` is the values for the last-run iteration. This PR syncs the variables' values with the ones generating the best result.



