### PR TITLE
Prepare v1.1 release metadata

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -4,9 +4,9 @@ name: "CodeQL"
 # yamllint disable-line rule:truthy
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
   workflow_dispatch:
   schedule:
     - cron: "30 1 * * 0"

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -5,7 +5,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -5,9 +5,9 @@ name: Sync labels
 on:
   push:
     branches:
-      - main
+      - master
     paths:
-      - .github/labels.yml
+      - .github/labels.yaml
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # DCCP
 
-[![build](https://github.com/cvxgrp/dccp/actions/workflows/release.yaml/badge.svg)](https://github.com/cvxgrp/dccp/actions/workflows/release.yaml)
+[![build](https://github.com/cvxgrp/dccp/actions/workflows/build.yml/badge.svg)](https://github.com/cvxgrp/dccp/actions/workflows/build.yml)
 [![docs](https://img.shields.io/badge/docs-online-brightgreen?logo=read-the-docs&style=flat)](https://www.cvxpy.org/dccp/)
 [![codecov](https://codecov.io/gh/cvxgrp/dccp/graph/badge.svg)](https://codecov.io/gh/cvxgrp/dccp)
-[![license](https://img.shields.io/github/license/cvxgrp/dccp)](https://github.com/cvxgrp/dccp/blob/main/LICENSE)
+[![license](https://img.shields.io/github/license/cvxgrp/dccp)](https://github.com/cvxgrp/dccp/blob/master/LICENSE)
 [![pypi](https://img.shields.io/pypi/v/dccp)](https://pypi.org/project/dccp/)
 
 DCCP package provides an organized heuristic for convex-concave programming.
@@ -16,7 +16,7 @@ DCCP is built on top of [CVXPY](http://www.cvxpy.org/), a domain-specific langua
 
 **Requirements:**
 - Python 3.11 or higher
-- CVXPY 1.5.4 or higher (tested with 1.5.4, 1.6.7, and 1.7.x)
+- CVXPY 1.9.0 or higher
 
 You can install the latest DCCP package via pip:
 
@@ -103,7 +103,7 @@ For all available parameters, see the [documentation](https://www.cvxpy.org/dccp
 
 ## License
 
-This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
+This project is licensed under GPLv3 - see the [LICENSE](LICENSE) file for details.
 
 ## Citation
 

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-You should first install [CVXPY 1.6.7](http://www.cvxpy.org/) or greater.
+You should first install [CVXPY 1.9.0](http://www.cvxpy.org/) or greater.
 
 ## Quick Install
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ packages = ["src/dccp"]
 include = ["src/dccp/py.typed"]
 
 [tool.hatch.build.targets.sdist]
-include = ["/src", "/examples", "/README.md", "/LICENSE", "/NOTICE"]
+include = ["/src", "/examples", "/README.md", "/LICENSE"]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary
- keep the project license as GPLv3 and update the README license text to match the existing LICENSE/package metadata
- update release-facing docs for the build workflow badge and CVXPY 1.9.0 minimum
- fix workflow branch triggers for master and correct the label sync path
- remove a stale sdist include for a missing NOTICE file

## Verification
- uv run pre-commit run check-toml --all-files
- uv run pre-commit run check-yaml --all-files
- uv run pre-commit run yamllint --all-files
- uv build
- inspected wheel metadata: License GPLv3, GPLv3 classifier, cvxpy>=1.9.0